### PR TITLE
intrastat fixes

### DIFF
--- a/intrastat_product/models/account_invoice.py
+++ b/intrastat_product/models/account_invoice.py
@@ -48,7 +48,7 @@ class AccountInvoice(models.Model):
         store=True, string='Intrastat Country', readonly=True)
     intrastat = fields.Char(
         string='Intrastat Declaration',
-        related='company_id.intrastat', store=True, readonly=True)
+        related='company_id.intrastat', readonly=True)
 
     @api.model
     def _default_intrastat_transaction(self):


### PR DESCRIPTION
PR with some fixes:

1) remove store=True from account.invoice,intrastat field

The store=True on account.invoice is a bug.
The intrastat field is only used for the account.invoice user interface and should take the value of the company_id,intrastat computed field at the time of viewing an invoice (hence a related non-stored field).
With store=True, all invoices are updated when changing the res.company,intrastat_arrivals or intrastat_dispatches fields which is an unwanted behaviour and takes up a lot of time for large databases.

2) accessory cost

I created a separate method which allows to turn off or modify the accessory cost in the localisation modules. In Belgium such a 'cost spreading' is not allowed, hence I need this method to have a correct Belgian declaration (I also hided the accessory cost from the computation lines in the belgian localisation module.

3) hashcode

small update: fields -> hc_fields to enhance code readability (no confusion with 'from openerp import fields')

4) region

region moved from extended to standard declaration logic.
